### PR TITLE
create zones and activate them by source

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,19 @@
 ---
+
 firewalld_allow_services: []
 firewalld_allow_ports: []
 firewalld_rich_rules: []
 
 firewalld_disable: false
+
+firewalld_zones: []
+## structure to provide zone names and sources
+# firewalld_zones:
+# - name: "teleport"
+# - name: "icinga"
+#   sources:
+#   - "{{ lookup('dig', 'test.example.com')}}/32"
+#   - 10.0.0.0/24"
+# - name: "bareos"
+
+...

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,8 @@
 ---
-# 'service reload' was not always working, needs complete reload
+
 - name: firewalld reload firewalld
-  command: firewall-cmd --complete-reload
+  systemd:
+    name: firewalld
+    state: reloaded
+
+...

--- a/tasks/cfg_firewalld_zone.yml
+++ b/tasks/cfg_firewalld_zone.yml
@@ -2,8 +2,8 @@
 
 - name: firewalld activate by source
   firewalld:
-    zone: "{{zone.name}}"
-    source: "{{source}}"
+    zone: "{{ zone.name }}"
+    source: "{{ source }}"
     state: enabled
     permanent: yes
   loop: "{{ zone.sources }}"

--- a/tasks/cfg_firewalld_zone.yml
+++ b/tasks/cfg_firewalld_zone.yml
@@ -1,0 +1,14 @@
+---
+
+- name: firewalld activate by source
+  firewalld:
+    zone: "{{zone.name}}"
+    source: "{{source}}"
+    state: enabled
+    permanent: yes
+  loop: "{{ zone.sources }}"
+  loop_control:
+    loop_var: source
+  notify: firewalld reload firewalld
+
+...

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -19,16 +19,16 @@
 
   - name: create firewalld zones
     firewalld:
-      zone: "{{zone.name}}"
+      zone: "{{ zone.name }}"
       state: present
       permanent: yes
-    register: firewalld_zones_created
+    register: firewalld_register_zones_created
     loop: "{{ firewalld_zones | default([]) }}"
     loop_control:
       loop_var: zone
 
   always:
-  - when: firewalld_zones_created.changed
+  - when: firewalld_register_zones_created.changed
     # see 'zone' notes: https://docs.ansible.com/ansible/latest/collections/ansible/posix/firewalld_module.html
     name: reload firewalld immediate
     systemd:

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -13,6 +13,38 @@
     enabled: no
   when: firewalld_disable
 
+- name: add firewalld zones
+  when: not firewalld_disable
+  block:
+
+  - name: create firewalld zones
+    firewalld:
+      zone: "{{zone.name}}"
+      state: present
+      permanent: yes
+    register: firewalld_zones_created
+    loop: "{{ firewalld_zones | default([]) }}"
+    loop_control:
+      loop_var: zone
+
+  always:
+  - when: firewalld_zones_created.changed
+    # see 'zone' notes: https://docs.ansible.com/ansible/latest/collections/ansible/posix/firewalld_module.html
+    name: reload firewalld immediate
+    systemd:
+      name: firewalld
+      state: reloaded
+
+- name: activate firewalld zones by source
+  when: not firewalld_disable
+  block:
+
+  - name: activate firewalld zones
+    include_tasks: cfg_firewalld_zone.yml
+    loop: "{{ firewalld_zones | default([]) }}"
+    loop_control:
+      loop_var: zone
+
 - name: add firewalld rules for services from vars
   firewalld:
     service: '{{ item.service }}'


### PR DESCRIPTION
create zones and allows to activate them via sources.
A direct reload on changes allows you to use new zones directly in the same paly-role.

I removed the complete-reload and used the recommended systemd mechanism for reload.
This should work for the specified platforms in meta data (`platforms: [ name: EL, versions: [7] ]`) without any problems.
